### PR TITLE
Add Support for missing SVGElement.classList in IE

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,9 @@
 if ("document" in window.self) {
 
   // Full polyfill for browsers with no classList support
-  if (!("classList" in document.createElement("_"))) {
+  // Including IE < Edge missing SVGElement.classList
+  if (!("classList" in document.createElement("_"))
+    || document.createElementNS && !("classList" in document.createElementNS("http://www.w3.org/2000/svg","g"))) {
 
   (function (view) {
 


### PR DESCRIPTION
Fixes #8 
Contains changes from https://github.com/eligrey/classList.js/commit/e87db36a95b2381a8c3ed44582a3926185cede70
